### PR TITLE
Optimized FTU illustration part lookup from HRA

### DIFF
--- a/react/src/components/Utils/Utils.js
+++ b/react/src/components/Utils/Utils.js
@@ -241,19 +241,11 @@ export const findFtuUrlById = (ftuPartsArray, searchId) => {
   }
 
   // Find match
-  const foundMatch = ftuPartsArray.find((part) => {
-    const ftuIri = part.ftu_iri?.value;
-    const ftuPartIri = part.ftu_part_iri?.value;
-
-    // Check if either IRI value exists and includes the searchId
-    const isMatch =
-      (ftuIri && ftuIri.includes(searchId)) ||
-      (ftuPartIri && ftuPartIri.includes(searchId));
-
-    return isMatch;
-  });
+  const foundMatch = ftuPartsArray.find((ftuPart) =>
+    ftuPart.ftu_iri === searchId || ftuPart.ftu_part_iri === searchId
+  );
 
   // Return match digital object URL
   console.log(foundMatch);
-  return foundMatch?.ftu_digital_object?.value || null;
+  return foundMatch?.ftu_digital_object || null;
 };

--- a/react/src/components/Utils/Utils.js
+++ b/react/src/components/Utils/Utils.js
@@ -242,7 +242,7 @@ export const findFtuUrlById = (ftuPartsArray, searchId) => {
 
   // Find match
   const foundMatch = ftuPartsArray.find((ftuPart) =>
-    ftuPart.ftu_iri === searchId || ftuPart.ftu_part_iri === searchId
+    ftuPart.ftu_iri.includes(searchId) || ftuPart.ftu_part_iri.includes(searchId)
   );
 
   // Return match digital object URL

--- a/react/src/contexts/FTUPartsContext.js
+++ b/react/src/contexts/FTUPartsContext.js
@@ -1,8 +1,8 @@
 import { createContext, useState, useEffect, useContext, useMemo } from "react";
 
-// URL from HRC
-const FTU_PARTS_URL =
-  "https://grlc.io/api-git/hubmapconsortium/ccf-grlc/subdir/hra/ftu-parts.json";
+// URL from HRA
+const FTU_ILLUSTRATIONS_URL =
+  "https://apps.humanatlas.io/api/v1/ftu-illustrations";
 
 // Define context
 const FtuPartsContext = createContext({
@@ -10,6 +10,24 @@ const FtuPartsContext = createContext({
   isLoading: true,
   error: null,
 });
+
+function getFtuPartsFromIllustrationsJsonLd(jsonld) {
+  if (jsonld['@graph']?.length > 0) {
+    const partsArray = jsonld['@graph'].map((illustration) =>
+      illustration.mapping.map((part) => (
+        {
+          ftu_digital_object: illustration['@id'],
+          ftu_iri: illustration.representation_of.replace('UBERON:', 'http://purl.obolibrary.org/obo/UBERON_'),
+          ftu_part_iri: part.representation_of
+        }
+      ))
+    ).flat();
+
+    return partsArray;
+  } else {
+     return []; 
+  } 
+}
 
 // Create Provider
 export const FtuPartsProvider = ({ children }) => {
@@ -21,12 +39,13 @@ export const FtuPartsProvider = ({ children }) => {
   useEffect(() => {
     const fetchFtuParts = async () => {
       try {
-        const response = await fetch(FTU_PARTS_URL);
+        const response = await fetch(FTU_ILLUSTRATIONS_URL);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
         const data = await response.json();
-        setFtuParts(data);
+        const ftuParts = getFtuPartsFromIllustrationsJsonLd(data);
+        setFtuParts(ftuParts);
       } catch (e) {
         console.error("Failed to fetch FTU parts:", e);
         setError(e.message);

--- a/react/src/pages/DocumentPage/DocumentPage.js
+++ b/react/src/pages/DocumentPage/DocumentPage.js
@@ -50,7 +50,7 @@ const DocumentPage = () => {
     if (!document || !ftuParts || ftuParts.length === 0) {
       return null;
     }
-    const ftuUrl = findFtuUrlById(ftuParts.results.bindings, id);
+    const ftuUrl = findFtuUrlById(ftuParts, id);
     console.log(ftuUrl);
     return ftuUrl;
   }, [document, ftuParts, id]);

--- a/react/src/pages/DocumentPage/DocumentPage.js
+++ b/react/src/pages/DocumentPage/DocumentPage.js
@@ -50,7 +50,7 @@ const DocumentPage = () => {
     if (!document || !ftuParts || ftuParts.length === 0) {
       return null;
     }
-    const ftuUrl = findFtuUrlById(ftuParts, id);
+    const ftuUrl = findFtuUrlById(ftuParts, coll + "_" + id);
     console.log(ftuUrl);
     return ftuUrl;
   }, [document, ftuParts, id]);


### PR DESCRIPTION
I updated the code to use the ftu illustrations jsonld endpoint instead of the grlc endpoint for creating the ftuParts lookup array. This endpoint is already used by the medical illustrations web component, so will result in less network traffic and will be super fast. I tested it a bit on my side by building and opening the react build, but did not test with the database backend. It seems to work, but please have a look. I think this will be a better/faster/more stable way of doing it.