### PR TITLE
Replace nested traversal inter-node edges with direct edge scan

### DIFF
--- a/arango_api/serializers.py
+++ b/arango_api/serializers.py
@@ -11,6 +11,7 @@ Usage in views:
 
 See: https://www.django-rest-framework.org/api-guide/serializers/
 """
+
 from rest_framework import serializers
 
 GRAPH_CHOICES = ["ontologies", "phenotypes"]
@@ -91,6 +92,17 @@ class ShortestPathsSerializer(serializers.Serializer):
         choices=["INBOUND", "OUTBOUND", "ANY"],
         required=False,
         default="ANY",
+    )
+
+
+class EdgesBetweenSerializer(GraphRequestSerializer):
+    """Serializer for finding edges between a set of nodes."""
+
+    node_ids = serializers.ListField(
+        child=serializers.CharField(),
+        required=True,
+        min_length=2,
+        help_text="List of at least 2 node IDs to find edges between",
     )
 
 
@@ -225,8 +237,12 @@ class PhaseSerializer(serializers.Serializer):
         required=False,
         default=list,
     )
-    originCollection = serializers.CharField(required=False, allow_null=True, default=None)
-    previousPhaseId = serializers.CharField(required=False, allow_null=True, default=None)
+    originCollection = serializers.CharField(
+        required=False, allow_null=True, default=None
+    )
+    previousPhaseId = serializers.CharField(
+        required=False, allow_null=True, default=None
+    )
     previousPhaseIds = serializers.ListField(
         child=serializers.CharField(),
         required=False,
@@ -249,9 +265,7 @@ class PhaseSerializer(serializers.Serializer):
         """Validate known keys within the settings dict (all optional)."""
         if "depth" in value:
             if not isinstance(value["depth"], int):
-                raise serializers.ValidationError(
-                    "'depth' must be an integer."
-                )
+                raise serializers.ValidationError("'depth' must be an integer.")
 
         if "edgeDirection" in value:
             allowed_directions = ("ANY", "INBOUND", "OUTBOUND")
@@ -276,9 +290,7 @@ class PhaseSerializer(serializers.Serializer):
 
         if "graphType" in value:
             if not isinstance(value["graphType"], str):
-                raise serializers.ValidationError(
-                    "'graphType' must be a string."
-                )
+                raise serializers.ValidationError("'graphType' must be a string.")
 
         if "includeInterNodeEdges" in value:
             if not isinstance(value["includeInterNodeEdges"], bool):

--- a/arango_api/services/graph_service.py
+++ b/arango_api/services/graph_service.py
@@ -1,11 +1,13 @@
 """
 Service for graph traversal operations.
 """
+
 import logging
 import re
 
 from arango_api.db import db_ontologies, GRAPH_NAME_ONTOLOGIES
 from arango_api.services.base import get_db_and_graph
+from arango_api.services.collection_service import get_collections
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +61,7 @@ def traverse_graph(
         negative_conditions = []
 
         for key, values in edge_filters.items():
-            safe_key = re.sub(r'[^a-zA-Z0-9_]', '', key)
+            safe_key = re.sub(r"[^a-zA-Z0-9_]", "", key)
 
             # Numeric range filter: values is a dict with min/max keys
             if isinstance(values, dict):
@@ -81,7 +83,9 @@ def traverse_graph(
                 pos_cond = f"({' AND '.join(range_parts)})"
                 positive_conditions.append(pos_cond)
 
-                neg_cond = f"(e.`{key}` != null AND NOT ({' AND '.join(range_parts[2:])}))"
+                neg_cond = (
+                    f"(e.`{key}` != null AND NOT ({' AND '.join(range_parts[2:])}))"
+                )
                 negative_conditions.append(neg_cond)
                 continue
 
@@ -111,26 +115,6 @@ def traverse_graph(
             filter_string = f"FILTER {' AND '.join(positive_conditions)}"
             prune_string = f"PRUNE {' OR '.join(negative_conditions)}"
 
-    # Build inter-node edges query section if enabled
-    inter_node_edges_query = ""
-    if include_inter_node_edges:
-        inter_node_edges_query = f"""
-         LET all_node_ids = all_nodes[*]._id
-
-         LET inter_node_edges = (
-             FOR v IN all_nodes
-                 FOR neighbor, e IN 1..1 ANY v._id GRAPH @graph
-                     OPTIONS {{ vertexCollections: @allowed_collections }}
-                     FILTER neighbor._id IN all_node_ids
-                     RETURN DISTINCT e
-         )
-
-         LET combined_links = UNION_DISTINCT(all_links, inter_node_edges)
-        """
-        links_field = "combined_links"
-    else:
-        links_field = "all_links"
-
     aql_query = f"""
      FOR start_node_id IN @node_ids
          LET start_node_doc = DOCUMENT(start_node_id)
@@ -154,19 +138,43 @@ def traverse_graph(
 
          LET all_links = UNIQUE(traversal[*].e)
 
-         {inter_node_edges_query}
-
          RETURN {{
              "start_node_id": start_node_id,
              "data": {{
                  "nodes": all_nodes,
-                 "links": {links_field}
+                 "links": all_links
              }}
          }}
      """
 
     cursor = db.aql.execute(aql_query, bind_vars=bind_vars)
     results = {item["start_node_id"]: item["data"] for item in cursor}
+
+    if include_inter_node_edges:
+        all_node_ids = set()
+        for data in results.values():
+            for node in data.get("nodes") or []:
+                if node and node.get("_id"):
+                    all_node_ids.add(node["_id"])
+
+        if all_node_ids:
+            inter_edges = find_inter_node_edges(list(all_node_ids), graph)
+            inter_by_id = {e["_id"]: e for e in inter_edges if e and e.get("_id")}
+
+            for data in results.values():
+                node_ids_in_result = {
+                    n["_id"] for n in (data.get("nodes") or []) if n and n.get("_id")
+                }
+                existing_ids = {
+                    l["_id"] for l in (data.get("links") or []) if l and l.get("_id")
+                }
+                for eid, edge in inter_by_id.items():
+                    if (
+                        eid not in existing_ids
+                        and edge.get("_from") in node_ids_in_result
+                        and edge.get("_to") in node_ids_in_result
+                    ):
+                        data["links"].append(edge)
 
     return results
 
@@ -216,6 +224,42 @@ def traverse_graph_advanced(
             aggregated_results.update(result_for_node)
 
     return aggregated_results
+
+
+def find_inter_node_edges(node_ids, graph="ontologies"):
+    """
+    Find all edges between a given set of nodes using direct edge collection scans.
+
+    Args:
+        node_ids (list): A list of node _id strings.
+        graph (str): The graph type ("ontologies" or "phenotypes").
+
+    Returns:
+        list: A list of edge documents connecting nodes in the set.
+    """
+    if not node_ids or len(node_ids) < 2:
+        return []
+
+    db, _ = get_db_and_graph(graph)
+    edge_collections = get_collections("edge", graph)
+
+    if not edge_collections:
+        return []
+
+    bind_vars = {"vertex_ids": node_ids}
+    subqueries = []
+    for i, coll in enumerate(edge_collections):
+        bind_key = f"@coll_{i}"
+        subqueries.append(
+            f"(FOR e IN @@coll_{i} FILTER e._from IN @vertex_ids"
+            f" AND e._to IN @vertex_ids RETURN e)"
+        )
+        bind_vars[bind_key] = coll
+
+    aql_query = f"RETURN UNION({', '.join(subqueries)})"
+    cursor = db.aql.execute(aql_query, bind_vars=bind_vars)
+    result = cursor.next()
+    return result if result else []
 
 
 def find_shortest_paths(node_ids, edge_direction="ANY"):

--- a/arango_api/services/workflow_service.py
+++ b/arango_api/services/workflow_service.py
@@ -8,6 +8,7 @@ Reuses existing services:
     - graph_service.traverse_graph_advanced() for graph traversal
     - collection_service.get_all_by_collection() for collection origins
 """
+
 import copy
 import logging
 
@@ -112,7 +113,7 @@ def _execute_phase(phase, all_phases, phase_results, phase_origin_ids, graph):
     # --- Handle multiplePhases combine (no API call) ---
     if origin_source == "multiplePhases":
         return _execute_combine_phase(
-            phase, all_phases, phase_results, phase_origin_ids, settings
+            phase, all_phases, phase_results, phase_origin_ids, settings, phase_graph
         )
 
     # --- Resolve origin node IDs ---
@@ -172,7 +173,7 @@ def _execute_phase(phase, all_phases, phase_results, phase_origin_ids, graph):
 
 
 def _execute_combine_phase(
-    phase, all_phases, phase_results, phase_origin_ids, settings
+    phase, all_phases, phase_results, phase_origin_ids, settings, graph=None
 ):
     """Handle multiplePhases origin: combine results from multiple prior phases."""
     source_phase_ids = phase.get("previousPhaseIds", [])
@@ -207,6 +208,20 @@ def _execute_combine_phase(
     combine_op = phase.get("phaseCombineOperation", "Intersection")
     combined_result = _perform_set_operation(source_graphs, combine_op)
 
+    if settings.get("includeInterNodeEdges", True) and graph:
+        node_ids = [n["_id"] for n in combined_result.get("nodes", []) if n.get("_id")]
+        if len(node_ids) >= 2:
+            inter_edges = graph_service.find_inter_node_edges(node_ids, graph)
+            existing_ids = {
+                l["_id"]
+                for l in (combined_result.get("links") or [])
+                if l and l.get("_id")
+            }
+            for edge in inter_edges:
+                if edge and edge.get("_id") and edge["_id"] not in existing_ids:
+                    combined_result["links"].append(edge)
+                    existing_ids.add(edge["_id"])
+
     return_collections = settings.get("returnCollections", [])
     if return_collections:
         combined_result = _apply_return_collections_filter(
@@ -216,9 +231,7 @@ def _execute_combine_phase(
     return combined_result, source_phase_ids
 
 
-def _resolve_origin_node_ids(
-    phase, all_phases, phase_results, phase_origin_ids, graph
-):
+def _resolve_origin_node_ids(phase, all_phases, phase_results, phase_origin_ids, graph):
     """Resolve origin node IDs based on the phase's originSource type."""
     origin_source = phase.get("originSource", "manual")
 
@@ -229,9 +242,7 @@ def _resolve_origin_node_ids(
         docs = collection_service.get_all_by_collection(collection_name, graph)
         node_ids = [doc["_id"] for doc in docs if doc.get("_id")]
         if not node_ids:
-            raise ValueError(
-                f'No nodes found in collection "{collection_name}".'
-            )
+            raise ValueError(f'No nodes found in collection "{collection_name}".')
         if len(node_ids) > MAX_COLLECTION_ORIGIN_NODES:
             logger.warning(
                 "Collection '%s' has %d nodes, truncating to %d",
@@ -314,7 +325,7 @@ def _perform_set_operation(graphs, operation):
     # Count node frequency across graphs
     node_frequency = {}  # node_id -> {"node": dict, "count": int}
     for graph in safe_graphs:
-        for node in (graph.get("nodes") or []):
+        for node in graph.get("nodes") or []:
             node_id = node.get("_id") or node.get("id")
             if not node_id:
                 continue
@@ -333,9 +344,7 @@ def _perform_set_operation(graphs, operation):
         ]
     elif op in ("symmetric difference", "symmetric_difference", "xor"):
         final_nodes = [
-            entry["node"]
-            for entry in node_frequency.values()
-            if entry["count"] == 1
+            entry["node"] for entry in node_frequency.values() if entry["count"] == 1
         ]
     else:
         # Union
@@ -350,7 +359,7 @@ def _perform_set_operation(graphs, operation):
     # Collect unique links
     unique_links = {}
     for graph in safe_graphs:
-        for link in (graph.get("links") or []):
+        for link in graph.get("links") or []:
             if not link:
                 continue
             key = (

--- a/arango_api/urls.py
+++ b/arango_api/urls.py
@@ -1,6 +1,7 @@
 """
 URL configuration for the ArangoDB API.
 """
+
 from django.urls import path
 
 from arango_api.views import (
@@ -10,6 +11,7 @@ from arango_api.views import (
     RelatedEdgesView,
     GraphTraversalView,
     ShortestPathsView,
+    EdgesBetweenView,
     SearchView,
     GetAllView,
     AQLQueryView,
@@ -34,6 +36,11 @@ urlpatterns = [
     # Graph traversal endpoints
     path("graph/", GraphTraversalView.as_view(), name="get_graph"),
     path("shortest_paths/", ShortestPathsView.as_view(), name="get_shortest_paths"),
+    path(
+        "graph/edges-between/",
+        EdgesBetweenView.as_view(),
+        name="get_edges_between",
+    ),
     # Edge endpoints
     path(
         "edges/<str:edge_coll>/<str:dr>/<str:item_coll>/<str:pk>/",

--- a/arango_api/views.py
+++ b/arango_api/views.py
@@ -11,6 +11,7 @@ Each view:
 
 See: https://www.django-rest-framework.org/api-guide/views/
 """
+
 import logging
 
 from django.http import HttpResponseNotFound
@@ -23,6 +24,7 @@ from arango_api.serializers import (
     GraphTraversalSerializer,
     AdvancedGraphTraversalSerializer,
     ShortestPathsSerializer,
+    EdgesBetweenSerializer,
     SearchRequestSerializer,
     AQLQuerySerializer,
     SunburstRequestSerializer,
@@ -142,6 +144,21 @@ class ShortestPathsView(APIView):
         return Response(results)
 
 
+class EdgesBetweenView(APIView):
+    """Find all edges between a given set of nodes."""
+
+    def post(self, request):
+        serializer = EdgesBetweenSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        edges = graph_service.find_inter_node_edges(
+            node_ids=data["node_ids"],
+            graph=data.get("graph", "ontologies"),
+        )
+        return Response(edges)
+
+
 class SearchView(APIView):
     """Search for items by term."""
 
@@ -206,7 +223,9 @@ class SunburstView(APIView):
             error_response = {"error": str(e)}
             if e.db_error:
                 error_response["db_error"] = e.db_error
-            return Response(error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                error_response, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class EdgeFilterOptionsView(APIView):
@@ -292,7 +311,9 @@ class WorkflowPresetsView(APIView):
     def get(self, request):
         from arango_api.workflow_presets import PRESET_CATEGORIES, WORKFLOW_PRESETS
 
-        return Response({
-            "presets": WORKFLOW_PRESETS,
-            "categories": PRESET_CATEGORIES,
-        })
+        return Response(
+            {
+                "presets": WORKFLOW_PRESETS,
+                "categories": PRESET_CATEGORIES,
+            }
+        )

--- a/react/tests/e2e/graph-inter-node-edges.spec.ts
+++ b/react/tests/e2e/graph-inter-node-edges.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+import {
+  filterErrorsContaining,
+  getCollectedErrors,
+  installErrorInstrumentation,
+} from "./utils/errorInstrumentation";
+import { doc, edge } from "./utils/testSeeds";
+
+const COLL = "TEST_DOCUMENT_COLLECTION";
+
+// Build a graph with 3 nodes (A, B, C) and traversal edges A→B, A→C.
+// When includeInterNodeEdges is true, the backend also returns B→C.
+function buildGraphWithInterNodeEdge(originId: string, includeInterEdge: boolean) {
+  const a = doc("A", "Node A");
+  const b = doc("B", "Node B");
+  const c = doc("C", "Node C");
+  const e1 = edge("E1", a._id, b._id, "traversal");
+  const e2 = edge("E2", a._id, c._id, "traversal");
+
+  const links = [e1, e2];
+  if (includeInterEdge) {
+    links.push(edge("E_INTER", b._id, c._id, "inter_node"));
+  }
+
+  return {
+    [originId]: {
+      nodes: [a, b, c],
+      links,
+    },
+  };
+}
+
+function setupCommonMocks(page: import("@playwright/test").Page) {
+  return Promise.all([
+    page.route("**/arango_api/collections/", async (route) => {
+      if (route.request().method() === "POST") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([COLL]),
+        });
+      }
+      return route.continue();
+    }),
+    page.route("**/arango_api/edge_filter_options/", async (route) => {
+      if (route.request().method() === "POST") {
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            Label: { type: "categorical", values: ["traversal", "inter_node"] },
+          }),
+        });
+      }
+      return route.continue();
+    }),
+    page.route("**/arango_api/document/details", async (route) => {
+      if (route.request().method() === "POST") {
+        const req = await route.request().postDataJSON();
+        const ids: string[] = req.document_ids || [];
+        const results = ids.map((id) => ({ _id: id, label: id.split("/")[1] }));
+        return route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(results),
+        });
+      }
+      return route.continue();
+    }),
+  ]);
+}
+
+test("Inter-node edges render when backend includes them", async ({ page }) => {
+  await installErrorInstrumentation(page);
+
+  const originId = `${COLL}/A`;
+
+  await setupCommonMocks(page);
+
+  await page.route("**/arango_api/graph/", async (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(buildGraphWithInterNodeEdge(originId, true)),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto(`/graph?origin=${encodeURIComponent(originId)}`);
+
+  // Wait for graph to render with all 3 nodes and 3 edges (including inter-node B→C)
+  await expect(page.locator("g.node")).toHaveCount(3, { timeout: 10000 });
+  await expect(page.locator("g.link")).toHaveCount(3, { timeout: 10000 });
+
+  const errors = getCollectedErrors(filterErrorsContaining("favicon"));
+  expect(errors).toHaveLength(0);
+});
+
+test("Graph shows only traversal edges when inter-node edge is absent", async ({ page }) => {
+  await installErrorInstrumentation(page);
+
+  const originId = `${COLL}/A`;
+
+  await setupCommonMocks(page);
+
+  await page.route("**/arango_api/graph/", async (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(buildGraphWithInterNodeEdge(originId, false)),
+      });
+    }
+    return route.continue();
+  });
+
+  await page.goto(`/graph?origin=${encodeURIComponent(originId)}`);
+
+  // Only 2 traversal edges, no inter-node edge
+  await expect(page.locator("g.node")).toHaveCount(3, { timeout: 10000 });
+  await expect(page.locator("g.link")).toHaveCount(2, { timeout: 10000 });
+
+  const errors = getCollectedErrors(filterErrorsContaining("favicon"));
+  expect(errors).toHaveLength(0);
+});

--- a/react/tests/e2e/graph-inter-node-edges.spec.ts
+++ b/react/tests/e2e/graph-inter-node-edges.spec.ts
@@ -88,13 +88,24 @@ test("Inter-node edges render when backend includes them", async ({ page }) => {
     return route.continue();
   });
 
-  await page.goto(`/graph?origin=${encodeURIComponent(originId)}`);
+  await page.addInitScript((origin) => {
+    const persistedRoot = {
+      nodesSlice: JSON.stringify({ originNodeIds: [origin] }),
+      savedGraphs: JSON.stringify({ graphs: [] }),
+      _persist: JSON.stringify({ version: -1, rehydrated: true }),
+    };
+    localStorage.setItem("persist:root", JSON.stringify(persistedRoot));
+  }, originId);
+
+  await page.goto("/#/graph");
+  await page.locator(".selected-items-container").waitFor({ state: "visible" });
+  await page.getByRole("button", { name: /Generate Graph|Update Graph/i }).click();
 
   // Wait for graph to render with all 3 nodes and 3 edges (including inter-node B→C)
   await expect(page.locator("g.node")).toHaveCount(3, { timeout: 10000 });
   await expect(page.locator("g.link")).toHaveCount(3, { timeout: 10000 });
 
-  const errors = getCollectedErrors(filterErrorsContaining("favicon"));
+  const errors = filterErrorsContaining(await getCollectedErrors(page), "favicon");
   expect(errors).toHaveLength(0);
 });
 
@@ -116,12 +127,23 @@ test("Graph shows only traversal edges when inter-node edge is absent", async ({
     return route.continue();
   });
 
-  await page.goto(`/graph?origin=${encodeURIComponent(originId)}`);
+  await page.addInitScript((origin) => {
+    const persistedRoot = {
+      nodesSlice: JSON.stringify({ originNodeIds: [origin] }),
+      savedGraphs: JSON.stringify({ graphs: [] }),
+      _persist: JSON.stringify({ version: -1, rehydrated: true }),
+    };
+    localStorage.setItem("persist:root", JSON.stringify(persistedRoot));
+  }, originId);
+
+  await page.goto("/#/graph");
+  await page.locator(".selected-items-container").waitFor({ state: "visible" });
+  await page.getByRole("button", { name: /Generate Graph|Update Graph/i }).click();
 
   // Only 2 traversal edges, no inter-node edge
   await expect(page.locator("g.node")).toHaveCount(3, { timeout: 10000 });
   await expect(page.locator("g.link")).toHaveCount(2, { timeout: 10000 });
 
-  const errors = getCollectedErrors(filterErrorsContaining("favicon"));
+  const errors = filterErrorsContaining(await getCollectedErrors(page), "favicon");
   expect(errors).toHaveLength(0);
 });


### PR DESCRIPTION
Extract find_inter_node_edges() using efficient FILTER e._from IN / e._to IN AQL across all edge collections. Wire into combine phases for cross-phase edge discovery. Add edges-between API endpoint and Playwright E2E test.