### PR TITLE
Correctly remove origin nodes

### DIFF
--- a/react/src/pages/GraphPage/GraphPage.js
+++ b/react/src/pages/GraphPage/GraphPage.js
@@ -6,7 +6,7 @@ import { GraphContext } from "contexts";
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchNodeDetailsByIds } from "services";
-import { initializeGraph, loadGraphFromJson, removeNodeFromSlice } from "store";
+import { clearNodesSlice, initializeGraph, loadGraphFromJson, removeNodeFromSlice } from "store";
 
 const GraphPage = () => {
   const dispatch = useDispatch();
@@ -25,7 +25,7 @@ const GraphPage = () => {
 
   // Add memoized calculation for stale state detection
   const isGraphStale = useMemo(() => {
-    if (!showGraph) return false;
+    if (!showGraph || nodeIds.length === 0) return false;
     return JSON.stringify(nodeIds) !== JSON.stringify(lastAppliedOriginNodeIds);
   }, [nodeIds, lastAppliedOriginNodeIds, showGraph]);
 
@@ -34,7 +34,7 @@ const GraphPage = () => {
   const hasInitializedRef = useRef(false);
   useEffect(() => {
     if (!hasInitializedRef.current) {
-      dispatch(initializeGraph({}));
+      dispatch(initializeGraph({ nodeIds: [] }));
       hasInitializedRef.current = true;
     }
   }, [dispatch]);
@@ -179,6 +179,15 @@ const GraphPage = () => {
         <button type="button" onClick={handleLoadFromJson} className="secondary-action-button">
           Load from File
         </button>
+        {nodeIds.length > 0 && (
+          <button
+            type="button"
+            onClick={() => dispatch(clearNodesSlice())}
+            className="secondary-action-button"
+          >
+            Clear All Nodes
+          </button>
+        )}
       </div>
 
       {isGraphStale && (

--- a/react/src/pages/WorkflowBuilderPage/WorkflowBuilderPage.js
+++ b/react/src/pages/WorkflowBuilderPage/WorkflowBuilderPage.js
@@ -73,13 +73,15 @@ const WorkflowBuilderPage = () => {
   const handleGraphReady = useCallback(
     (graphData) => {
       if (graphData?.nodes?.length > 0) {
-        const nodeIds = graphData.nodes.map((n) => n._id);
+        // Use the actual origin node IDs from the active phase, not all graph nodes.
+        const activePhase = phases.find((p) => p.id === activePhaseId);
+        const nodeIds = activePhase?._executedOriginNodeIds || activePhase?.originNodeIds || [];
 
         // Set graph data and origin node IDs in a single dispatch.
         // The setGraphData reducer also sets depth=0 and useFocusNodes=false
         // and snapshots lastAppliedSettings so the "Apply Changes" mechanism
         // works for query-affecting settings in the graph options panel.
-        dispatch(setGraphData({ graphData, originNodeIds: nodeIds }));
+        dispatch(setGraphData({ graphData, originNodeIds: nodeIds, source: "workflow" }));
 
         setHasResults(true);
 
@@ -94,7 +96,7 @@ const WorkflowBuilderPage = () => {
         }, 100);
       }
     },
-    [dispatch],
+    [dispatch, phases, activePhaseId],
   );
 
   return (


### PR DESCRIPTION
Origin nodes would not always be removed from the store, which caused specific errors in certain graph modes like shortest paths.