### PR TITLE
Fix labels not appearing after graph generation

### DIFF
--- a/react/src/components/ForceGraphConstructor/ForceGraphConstructor.js
+++ b/react/src/components/ForceGraphConstructor/ForceGraphConstructor.js
@@ -104,9 +104,7 @@ function ForceGraphConstructor(
   let currentLabelStates = { ...mergedOptions.initialLabelStates };
 
   // Centralized function to manage label visibility based on zoom and user settings.
-  // Labels are hidden when the simulation is active (alpha above threshold).
   function updateLabelVisibilityOnZoom(k) {
-    if (simulation.alpha() > 0.001) return;
     // Calculate the zoom threshold needed to meet the minimum visible font size.
     const nodeLabelThreshold = mergedOptions.minVisibleFontSize / mergedOptions.nodeFontSize;
     const linkLabelThreshold = mergedOptions.minVisibleFontSize / mergedOptions.linkFontSize;
@@ -144,7 +142,11 @@ function ForceGraphConstructor(
     .zoom()
     .on("zoom", (event) => {
       g.attr("transform", event.transform);
-      // Update label visibility every time zoom changes.
+      // Skip label re-evaluation while the simulation is hot — the
+      // post-settle callback will apply final visibility. The guard lives
+      // here (not inside updateLabelVisibilityOnZoom) so that post-simulation
+      // callers can apply visibility regardless of the current alpha value.
+      if (simulation.alpha() > 0.001) return;
       updateLabelVisibilityOnZoom(event.transform.k);
     })
     .on("start", mergedOptions.interactionCallback);


### PR DESCRIPTION
The updateLabelVisibilityOnZoom alpha guard was early-returning when post-simulation callers ran, because waitForAlpha resolves at a threshold of max(1/N, 0.002) — always above 0.001 — and simulation.stop() freezes alpha at that value. Non-force layouts bumped alpha to 0.5 before calling the onComplete hook, so they hit the same guard. Labels only reappeared once something (drag, restore, natural decay past alphaMin) dropped alpha below 0.001.

Move the guard to the zoom handler itself, where it belongs — callers that run after a layout settles can now apply visibility unconditionally.