### PR TITLE
Standardize branding on NLM-CKN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ venv/
 /.claude
 CLAUDE.md
 /core/sh/build-*
+.worktrees/

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -1,6 +1,6 @@
-# Cell-KN CloudFormation Infrastructure
+# NLM-CKN CloudFormation Infrastructure
 
-CloudFormation-based infrastructure for deploying Cell-KN application to AWS.
+CloudFormation-based infrastructure for deploying the NLM-CKN application to AWS.
 
 **IMPORTANT**: All stacks must be deployed in `us-east-1` due to CloudFront's ACM certificate region requirement.
 

--- a/react/README.md
+++ b/react/README.md
@@ -1,6 +1,6 @@
-# Cell Knowledge Network - React Frontend
+# NLM-CKN - React Frontend
 
-This is the React frontend for the NLM Cell Knowledge Network MVP application. It provides interactive visualizations for exploring biological knowledge graphs including cell types, anatomical structures, and their relationships.
+This is the React frontend for the NLM Cell Knowledge Network (NLM-CKN) MVP application. It provides interactive visualizations for exploring biological knowledge graphs including cell types, anatomical structures, and their relationships.
 
 ## 🛠 Tech Stack
 

--- a/react/src/components/SearchBar/SearchBar.js
+++ b/react/src/components/SearchBar/SearchBar.js
@@ -34,7 +34,7 @@ const SearchBar = () => {
           <input
             type="text"
             className="search-input"
-            placeholder="Search NCKN..."
+            placeholder="Search NLM-CKN..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onFocus={() => setIsOpen(true)}

--- a/react/src/components/SearchBar/SearchBar.test.js
+++ b/react/src/components/SearchBar/SearchBar.test.js
@@ -34,7 +34,7 @@ describe("SearchBar Component", () => {
   it("renders the input field and child components", () => {
     renderWithContext(<SearchBar />);
 
-    const input = screen.getByPlaceholderText("Search NCKN...");
+    const input = screen.getByPlaceholderText("Search NLM-CKN...");
     expect(input).toBeInTheDocument();
 
     const resultsTable = screen.getByTestId("search-results-table");
@@ -43,7 +43,7 @@ describe("SearchBar Component", () => {
 
   it("shows search results dropdown when input has focus and text", async () => {
     renderWithContext(<SearchBar />);
-    const input = screen.getByPlaceholderText("Search NCKN...");
+    const input = screen.getByPlaceholderText("Search NLM-CKN...");
 
     // Focus and type in the input
     fireEvent.focus(input);
@@ -63,7 +63,7 @@ describe("SearchBar Component", () => {
 
   it("hides search results when clicking outside", async () => {
     renderWithContext(<SearchBar />);
-    const input = screen.getByPlaceholderText("Search NCKN...");
+    const input = screen.getByPlaceholderText("Search NLM-CKN...");
 
     // Focus and type to show results
     fireEvent.focus(input);

--- a/react/src/pages/SearchPage/SearchPage.js
+++ b/react/src/pages/SearchPage/SearchPage.js
@@ -12,7 +12,7 @@ const SearchPage = () => {
       </div>
 
       <div className="about-section-container">
-        <h2 className="about-title">About NCKN</h2>
+        <h2 className="about-title">About NLM-CKN</h2>
         <p>
           The National Library of Medicine (NLM) Cell Knowledge Network is a knowledgebase focused
           on cell characteristics (phenotypes) derived from single-cell technologies. It integrates

--- a/react/src/styles/index.css
+++ b/react/src/styles/index.css
@@ -1,5 +1,5 @@
 /* 
- * Cell Knowledge Network MVP UI - Styles Entry Point
+ * NLM-CKN MVP UI - Styles Entry Point
  * 
  * This file imports all modular CSS files in the correct order.
  * Import order: variables → base → layout → navigation → components → graph → pages → utilities → responsive

--- a/react/tests/README.md
+++ b/react/tests/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This test suite uses **Playwright** for end-to-end (E2E) testing of the Cell Knowledge Network MVP UI. The tests validate:
+This test suite uses **Playwright** for end-to-end (E2E) testing of the NLM-CKN MVP UI. The tests validate:
 
 - **Page navigation** and routing behavior
 - **User interactions** with forms, search, and visualizations

--- a/react/tests/e2e/graph-page-origin.spec.ts
+++ b/react/tests/e2e/graph-page-origin.spec.ts
@@ -99,7 +99,7 @@ test("Graph page shows two selected nodes and builds graph with both origins", a
 
   // Add from Search
   await page.goto("/");
-  await page.getByPlaceholder("Search NCKN...").fill("sea");
+  await page.getByPlaceholder("Search NLM-CKN...").fill("sea");
   // Ensure result
   await expect(page.locator(".unified-search-results-list")).toContainText("Search Node");
   // Click add button

--- a/react/tests/e2e/graph-page-settings.spec.ts
+++ b/react/tests/e2e/graph-page-settings.spec.ts
@@ -270,7 +270,7 @@ test("Graph export buttons exist and trigger download", async ({ page }) => {
   await page.goto("/");
 
   // Search
-  await page.getByPlaceholder("Search NCKN...").fill("Root Node");
+  await page.getByPlaceholder("Search NLM-CKN...").fill("Root Node");
   // Wait for results
   await page.locator(".unified-search-results-list").waitFor({ state: "visible" });
 

--- a/react/tests/e2e/not-found.spec.ts
+++ b/react/tests/e2e/not-found.spec.ts
@@ -21,7 +21,7 @@ test("Navigating to invalid route shows 404 page", async ({ page }) => {
 
   // Verify we are back at home (Search page)
   await expect(page).toHaveURL(/#\/$/);
-  await expect(page.getByPlaceholder("Search NCKN...")).toBeVisible();
+  await expect(page.getByPlaceholder("Search NLM-CKN...")).toBeVisible();
 
   // Verify no "split of undefined" errors occurred
   expect(filterErrorsContaining(await getCollectedErrors(page), "split").length).toBe(0);

--- a/react/tests/e2e/search.spec.ts
+++ b/react/tests/e2e/search.spec.ts
@@ -45,7 +45,7 @@ test('searching "lung" navigates to lung page', async ({ page }) => {
   await page.goto("/");
 
   // Input
-  const input = page.getByPlaceholder("Search NCKN...");
+  const input = page.getByPlaceholder("Search NLM-CKN...");
   await expect(input).toBeVisible();
 
   // Type
@@ -98,7 +98,7 @@ test("exact match appears first when backend returns correctly sorted results", 
 
   await page.goto("/");
 
-  const input = page.getByPlaceholder("Search NCKN...");
+  const input = page.getByPlaceholder("Search NLM-CKN...");
   await expect(input).toBeVisible();
   await input.fill("lung");
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Deployment Scripts
 
-Automated deployment scripts for Cell-KN CloudFormation infrastructure and applications.
+Automated deployment scripts for NLM-CKN CloudFormation infrastructure and applications.
 
 ```
 scripts/


### PR DESCRIPTION
Replace NCKN, Cell-KN, and bare "Cell Knowledge Network" references with NLM-CKN in user-facing copy and developer READMEs. Keeps the spelled-out "NLM Cell Knowledge Network" form (what NLM-CKN abbreviates) where used as the full product name. Infrastructure names (env DB names, AWS/CFN resources) are left unchanged.

- SearchBar placeholder and SearchPage heading
- Matching Jest + Playwright assertions
- README.md, scripts/README.md, cloudformation/README.md, react/README.md, react/tests/README.md, react/src/styles/index.css
- Add .worktrees/ to .gitignore