### PR TITLE
Promote Springbok-LLC main to upstream

### DIFF
--- a/.github/workflows/promote-to-upstream.yml
+++ b/.github/workflows/promote-to-upstream.yml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   promote:
+    # Skip when this workflow runs on the NIH-NLM upstream (it gets there via
+    # the FF/merge promotions). Only fire on the Springbok-LLC fork.
+    if: github.repository_owner == 'Springbok-LLC'
     runs-on: ubuntu-latest
     steps:
       - name: Fast-forward or merge fork into upstream


### PR DESCRIPTION
Automated promotion from Springbok-LLC fork. Merged with admin bypass — Springbok-LLC's CI gates the commits before they land here.