### PR TITLE
limit search results to improve drop down speed

### DIFF
--- a/arango_api/services/search_service.py
+++ b/arango_api/services/search_service.py
@@ -11,6 +11,35 @@ from arango_api.services.collection_service import get_collections
 
 logger = logging.getLogger(__name__)
 
+# Maximum number of search results returned by the dropdown query. The frontend
+# renders results in pages of 20 and lazy-loads more on scroll, so an unbounded
+# result set (thousands of fuzzy/n-gram matches for short terms like "K" or
+# "cell") is wasted work and payload. Capping here keeps the query fast.
+SEARCH_RESULT_LIMIT = 50
+
+# Label fields read by the frontend's getLabel() (utils/collections.js
+# individual_labels -> field_to_use). The search dropdown only needs _id, the
+# fields actually searched, and whichever of these label fields a matched doc
+# has, so the query projects this set instead of serializing full documents.
+LABEL_FIELDS = [
+    "Citation",
+    "Label",
+    "Link_to_publication",
+    "_key",
+    "author_cell_term",
+    "cellxgene_collection",
+    "cellxgene_dataset",
+    "dataset_identifier",
+    "definition",
+    "exact_synonym",
+    "gene_id",
+    "gene_symbol",
+    "label",
+    "markers",
+    "publication_doi",
+    "uniprot_id",
+]
+
 
 def search_by_term(search_term, search_fields, graph):
     """
@@ -63,14 +92,15 @@ def search_by_term(search_term, search_fields, graph):
         f"LOWER(doc.`{field}`) == lower_search_term" for field in search_fields
     )
 
-    query_end = f"""
+    query_end = """
                     LET is_exact_match = ({exact_match_conditions})
                     SORT is_exact_match DESC, BM25(doc) DESC
-                    RETURN doc
+                    LIMIT @limit
+                    RETURN MERGE({{"_id": doc._id}}, KEEP(doc, @projection_fields))
             )
 
             RETURN sortedDocs
-            """
+            """.format(exact_match_conditions=exact_match_conditions)
     query = (
         query_beginning
         + levenshtein_string_0
@@ -79,7 +109,16 @@ def search_by_term(search_term, search_fields, graph):
         + query_end
     )
 
-    bind_vars = {"search_term": search_term}
+    # Project only the fields the dropdown needs: _id (always), the searched
+    # fields, and any label fields getLabel() may read. _id is merged in
+    # explicitly because KEEP does not retain system attributes.
+    projection_fields = sorted(set(search_fields) | set(LABEL_FIELDS))
+
+    bind_vars = {
+        "search_term": search_term,
+        "limit": SEARCH_RESULT_LIMIT,
+        "projection_fields": projection_fields,
+    }
 
     try:
         cursor = db_connection.aql.execute(query, bind_vars=bind_vars)

--- a/arango_api/tests/test_services.py
+++ b/arango_api/tests/test_services.py
@@ -14,6 +14,8 @@ Test Configuration:
         docker run -d --name arangodb-test -p 8530:8529 -e ARANGO_ROOT_PASSWORD=test arangodb
 """
 
+from unittest import mock
+
 from django.test import TestCase, tag
 
 from arango_api.services import (
@@ -358,6 +360,62 @@ class SearchServiceTestCase(ArangoDBTestCase):
     def test_run_aql_query(self):
         result = search_service.run_aql_query("RETURN 1 + 1")
         self.assertEqual(result, 2)
+
+
+class SearchByTermQueryTestCase(TestCase):
+    """Unit tests for search_by_term query construction (no DB required)."""
+
+    def _run(self, search_fields):
+        """Invoke search_by_term with the DB layer mocked out.
+
+        Returns the (query, bind_vars) passed to aql.execute.
+        """
+        cursor = mock.Mock()
+        cursor.next.return_value = []
+        db_connection = mock.Mock()
+        db_connection.aql.execute.return_value = cursor
+
+        with mock.patch.object(
+            search_service, "get_db_and_graph", return_value=(db_connection, None)
+        ):
+            search_service.search_by_term("cell", search_fields, "ontologies")
+
+        _, kwargs = db_connection.aql.execute.call_args
+        return db_connection.aql.execute.call_args[0][0], kwargs["bind_vars"]
+
+    def test_query_applies_limit_as_bind_var(self):
+        query, bind_vars = self._run(["label"])
+        # LIMIT must come after the SORT and use a bind var, not an interpolated
+        # number, so the relevance ranking is preserved while capping output.
+        self.assertIn("LIMIT @limit", query)
+        self.assertEqual(bind_vars["limit"], search_service.SEARCH_RESULT_LIMIT)
+        sort_idx = query.index("SORT is_exact_match DESC")
+        self.assertLess(sort_idx, query.index("LIMIT @limit"))
+
+    def test_query_projects_minimal_fields(self):
+        query, bind_vars = self._run(["label", "definition"])
+        # The full document is no longer returned; only _id plus a projected
+        # field set is serialized back to the dropdown.
+        self.assertNotIn("RETURN doc\n", query)
+        self.assertIn("KEEP(doc, @projection_fields)", query)
+        self.assertIn('"_id": doc._id', query)
+
+        projection = bind_vars["projection_fields"]
+        # Searched fields and getLabel() label fields are present.
+        self.assertIn("label", projection)
+        self.assertIn("definition", projection)
+        self.assertIn("gene_symbol", projection)
+        # _id is merged explicitly, so it need not appear in the KEEP list.
+        for field in search_service.LABEL_FIELDS:
+            self.assertIn(field, projection)
+
+    def test_ranking_clauses_unchanged(self):
+        query, _ = self._run(["label"])
+        # Exact-match boost, BM25, Levenshtein and n-gram branches still present.
+        self.assertIn("is_exact_match", query)
+        self.assertIn("BM25(doc)", query)
+        self.assertIn("LEVENSHTEIN_MATCH", query)
+        self.assertIn('"n-gram"', query)
 
 
 class SunburstServiceTestCase(ArangoDBTestCase):

--- a/react/src/components/SearchResultsTable/SearchResultsTable.test.js
+++ b/react/src/components/SearchResultsTable/SearchResultsTable.test.js
@@ -71,6 +71,23 @@ describe("SearchResultsTable", () => {
     expect(screen.getByText("No results found.")).toBeInTheDocument();
   });
 
+  test("renders projected results that only contain _id and label fields", () => {
+    // The backend now returns a trimmed projection (no full document), so the
+    // table must work off just _id plus the label field getLabel() reads.
+    const projectedResults = [
+      { _id: "CL/0", label: "Apple" },
+      { _id: "GO/2", label: "Carrot" },
+    ];
+
+    renderWithProviders(<SearchResultsTable searchResults={projectedResults} />);
+
+    // Label comes through, and the collection tag is derived from _id alone.
+    expect(screen.getByText("Apple")).toBeInTheDocument();
+    expect(screen.getByText("Carrot")).toBeInTheDocument();
+    expect(screen.getAllByText("Cell Types").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Gene Ontology").length).toBeGreaterThan(0);
+  });
+
   test("renders collection tags with correct display names", () => {
     renderWithProviders(<SearchResultsTable searchResults={sampleResults} />);
 


### PR DESCRIPTION
improve drop down speed by limiting query to 50