### PR TITLE
301 redirects from `cell-kn.org` and `nlm-ckn.org` to `https://stage.nlm-ckn.org`

### DIFF
--- a/cloudformation/redirect/README.md
+++ b/cloudformation/redirect/README.md
@@ -1,0 +1,73 @@
+# Redirect to stage
+
+CloudFront distribution that issues **301 redirects** from `cell-kn.org` and
+`nlm-ckn.org` to `https://stage.nlm-ckn.org`, preserving the request path and
+query string.
+
+## What the template creates
+
+| Resource | Purpose |
+| --- | --- |
+| `AWS::CloudFront::Function` (`redirect-to-stage`) | viewer-request function that returns a `301 Moved Permanently` to `https://stage.nlm-ckn.org<uri><?query>` |
+| `AWS::CloudFront::Distribution` (comment `Redirect to stage`) | distribution with aliases `cell-kn.org` and `nlm-ckn.org`, function attached to the default behavior |
+| `AWS::Route53::RecordSet` ×4 | A + AAAA alias records for both apex domains pointing at the distribution |
+
+## Prerequisite — ACM certificate (not created here)
+
+CloudFront serves these domains over HTTPS, so it needs a certificate covering
+**both** apex names. ACM certs for CloudFront **must live in `us-east-1`**.
+
+A combined cert has already been requested, DNS-validated, and issued:
+
+```
+arn:aws:acm:us-east-1:952291113202:certificate/64062cb5-af4b-4501-accb-d1008304b3a5
+  domains: nlm-ckn.org, cell-kn.org   status: ISSUED   region: us-east-1
+```
+
+This ARN is already filled into `parameters.json`. (Note: a single distribution
+attaches one cert covering all its aliases — the pre-existing `cell-kn.org` and
+`stage.nlm-ckn.org` certs could not be combined, so this new two-SAN cert was
+created. It isn't managed by this template because DNS-validated ACM certs block
+CloudFormation stack creation until validation resolves.)
+
+## Deploy
+
+This stack **must** be deployed in `us-east-1` (CloudFront functions + certs).
+
+Fill in `CertificateArn` in `parameters.json` (the hosted zone IDs are already
+set), then:
+
+```bash
+aws cloudformation deploy \
+  --region us-east-1 \
+  --stack-name redirect-to-stage \
+  --template-file redirect.yaml \
+  --parameter-overrides file://parameters.json
+```
+
+Hosted zones (already wired into `parameters.json`):
+
+| Domain | Hosted Zone ID |
+| --- | --- |
+| `cell-kn.org` | `Z0441030102JW92C98Q3U` |
+| `nlm-ckn.org` | `Z05089951YM1345O1XAHB` |
+
+## Is this everything needed to redirect the two hostnames to stage?
+
+Yes, for the redirect path itself — with two requirements called out:
+
+1. **ACM certificate (us-east-1) covering both apex names** — required, supplied
+   via `CertificateArn`. Without an alias-matching cert CloudFront rejects the
+   request before the function runs.
+2. **Apex DNS must be in Route 53** — the A/AAAA alias records assume `cell-kn.org`
+   and `nlm-ckn.org` are hosted in the Route 53 zones identified by the zone-ID
+   parameters. If a domain's authoritative DNS is elsewhere, point its apex at the
+   CloudFront domain there instead.
+
+Notes:
+- The redirect is `https://stage.nlm-ckn.org`. The target (`stage.nlm-ckn.org`)
+  must already be serving HTTPS — it is, via the existing `frontend.yaml` stack.
+- `http://` hits also redirect (viewer protocol policy `allow-all`, function runs
+  on every viewer request) — browsers requesting `http://cell-kn.org` get the
+  301 straight to the https stage URL.
+- Path and query string are preserved in the redirect Location.

--- a/cloudformation/redirect/parameters.json
+++ b/cloudformation/redirect/parameters.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "CertificateArn",
+    "ParameterValue": "arn:aws:acm:us-east-1:952291113202:certificate/64062cb5-af4b-4501-accb-d1008304b3a5"
+  },
+  {
+    "ParameterKey": "CellKnHostedZoneId",
+    "ParameterValue": "Z0441030102JW92C98Q3U"
+  },
+  {
+    "ParameterKey": "NlmCknHostedZoneId",
+    "ParameterValue": "Z05089951YM1345O1XAHB"
+  },
+  {
+    "ParameterKey": "RedirectTarget",
+    "ParameterValue": "stage.nlm-ckn.org"
+  }
+]

--- a/cloudformation/redirect/redirect.yaml
+++ b/cloudformation/redirect/redirect.yaml
@@ -1,0 +1,193 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFront distribution that 301-redirects cell-kn.org and nlm-ckn.org to stage.nlm-ckn.org'
+
+# ==============================================================================
+# IMPORTANT: This stack MUST be deployed in us-east-1.
+# CloudFront only accepts ACM certificates and CloudFront functions from us-east-1.
+# ==============================================================================
+
+Parameters:
+  CertificateArn:
+    Type: String
+    Description: >-
+      ARN of an ACM certificate (in us-east-1) that covers BOTH cell-kn.org and
+      nlm-ckn.org. The cert must already be issued/validated before deploying this
+      stack. A single cert with two SANs, or a wildcard covering both apex names,
+      works.
+
+  CellKnHostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route 53 hosted zone ID for cell-kn.org
+
+  NlmCknHostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route 53 hosted zone ID for nlm-ckn.org
+
+  RedirectTarget:
+    Type: String
+    Default: stage.nlm-ckn.org
+    Description: Host that both source domains redirect to
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Certificate
+        Parameters:
+          - CertificateArn
+      - Label:
+          default: Hosted Zones
+        Parameters:
+          - CellKnHostedZoneId
+          - NlmCknHostedZoneId
+      - Label:
+          default: Redirect
+        Parameters:
+          - RedirectTarget
+
+Resources:
+  # ============================================================================
+  # CloudFront Function - viewer-request 301 redirect
+  # ============================================================================
+  RedirectFunction:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: redirect-to-stage
+      AutoPublish: true
+      FunctionConfig:
+        Comment: '301 redirect cell-kn.org / nlm-ckn.org to stage.nlm-ckn.org'
+        Runtime: cloudfront-js-2.0
+      FunctionCode: !Sub |
+        function handler(event) {
+            var request = event.request;
+            var target = '${RedirectTarget}';
+
+            var qs = '';
+            for (var key in request.querystring) {
+                var v = request.querystring[key];
+                qs += (qs ? '&' : '') + key + (v.value !== '' ? '=' + v.value : '');
+                if (v.multiValue) {
+                    for (var i = 0; i < v.multiValue.length; i++) {
+                        qs += '&' + key + '=' + v.multiValue[i].value;
+                    }
+                }
+            }
+
+            var location = 'https://' + target + request.uri + (qs ? '?' + qs : '');
+
+            return {
+                statusCode: 301,
+                statusDescription: 'Moved Permanently',
+                headers: {
+                    'location': { value: location }
+                }
+            };
+        }
+
+  # ============================================================================
+  # CloudFront Distribution
+  # ============================================================================
+  RedirectDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: 'Redirect to stage'
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        PriceClass: PriceClass_100
+        Aliases:
+          - cell-kn.org
+          - nlm-ckn.org
+
+        # A real origin is required even though the viewer-request function
+        # short-circuits every request with a 301 before the origin is reached.
+        Origins:
+          - Id: PlaceholderOrigin
+            DomainName: !Ref RedirectTarget
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+
+        DefaultCacheBehavior:
+          TargetOriginId: PlaceholderOrigin
+          ViewerProtocolPolicy: allow-all
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: false
+          CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad  # Managed-CachingDisabled
+          FunctionAssociations:
+            - EventType: viewer-request
+              FunctionARN: !GetAtt RedirectFunction.FunctionMetadata.FunctionARN
+
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+
+      Tags:
+        - Key: Name
+          Value: redirect-to-stage
+        - Key: ManagedBy
+          Value: CloudFormation
+
+  # ============================================================================
+  # Route 53 A (alias) records -> CloudFront
+  # ============================================================================
+  CellKnRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref CellKnHostedZoneId
+      Name: cell-kn.org
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt RedirectDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2  # CloudFront hosted zone ID (constant)
+        EvaluateTargetHealth: false
+
+  CellKnRecordIpv6:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref CellKnHostedZoneId
+      Name: cell-kn.org
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt RedirectDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+  NlmCknRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref NlmCknHostedZoneId
+      Name: nlm-ckn.org
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt RedirectDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+  NlmCknRecordIpv6:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref NlmCknHostedZoneId
+      Name: nlm-ckn.org
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt RedirectDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+Outputs:
+  DistributionId:
+    Description: CloudFront distribution ID
+    Value: !Ref RedirectDistribution
+
+  DistributionDomainName:
+    Description: CloudFront distribution domain name
+    Value: !GetAtt RedirectDistribution.DomainName


### PR DESCRIPTION
CloudFront distribution that issues **301 redirects** from `cell-kn.org` and
`nlm-ckn.org` to `https://stage.nlm-ckn.org`, preserving the request path and
query string.

https://cell-kn.org and https://nlm-ckn.org redirect to https://stage.nlm-ckn.org