### PR TITLE
Promote Springbok-LLC main to upstream

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -40,6 +40,8 @@ jobs:
           node-version: '20'
 
       - name: Deploy frontend (build, sync to S3, invalidate CloudFront)
+        env:
+          VERSION: ${{ github.ref_name }}
         run: ./scripts/app/deploy-frontend.sh stage
 
       - name: Deploy dataset

--- a/arango_api/tests/test_views.py
+++ b/arango_api/tests/test_views.py
@@ -439,7 +439,7 @@ class VersionViewTestCase(SimpleTestCase):
             response = self.client.get(reverse("get_version"))
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        self.assertIn("ui_version", data)
+        self.assertIn("backend_version", data)
         self.assertIn("etl_version", data)
         self.assertIn("pinned_etl_version", data)
 
@@ -477,11 +477,11 @@ class VersionViewTestCase(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["pinned_etl_version"], "unknown")
 
-    def test_ui_version_reflects_setting(self):
+    def test_backend_version_reflects_setting(self):
         with override_settings(UI_VERSION="v9.9.9"), self._patch_loaded("v1.5.0-rc.1"):
             response = self.client.get(reverse("get_version"))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["ui_version"], "v9.9.9")
+        self.assertEqual(response.json()["backend_version"], "v9.9.9")
 
 
 class CircuitBreakerOpenResponseTestCase(SimpleTestCase):

--- a/arango_api/views.py
+++ b/arango_api/views.py
@@ -382,9 +382,13 @@ class WorkflowPresetsView(APIView):
 
 
 class VersionView(APIView):
-    """Return the UI and ETL versions for display to the user.
+    """Return the backend, dataset, and pinned dataset versions.
 
-    The UI version comes from the ``UI_VERSION`` setting (injected at deploy time).
+    ``backend_version`` is the backend image tag (the ``UI_VERSION`` setting,
+    injected at build time). It is reported for diagnosis but not displayed: the
+    UI version users see is baked into the frontend bundle, which deploys
+    independently of this image.
+
     The ETL version is read from the ``ckn_meta`` marker stamped into ArangoDB by
     whichever script restored the data, so it describes the dataset actually
     loaded. ``pinned_etl_version`` is the committed ``ETL_VERSION`` file — the
@@ -407,7 +411,7 @@ class VersionView(APIView):
 
         return Response(
             {
-                "ui_version": settings.UI_VERSION,
+                "backend_version": settings.UI_VERSION,
                 "etl_version": version_service.get_loaded_etl_version(),
                 "pinned_etl_version": pinned_etl_version,
             }

--- a/react/src/components/Footer/Footer.js
+++ b/react/src/components/Footer/Footer.js
@@ -17,6 +17,11 @@ const Footer = () => {
     };
   }, []);
 
+  // Baked into the bundle at build time (see scripts/app/deploy-frontend.sh), so
+  // it describes the code actually running rather than whatever the backend was
+  // last built from. Falls back to "dev" for local builds.
+  const uiVersion = process.env.REACT_APP_VERSION || "dev";
+
   // The pin (ETL_VERSION in the repo) is what this checkout intends to run; the
   // loaded version is what the database actually holds. They agree in normal
   // operation, so show the pin only when it would tell the user something.
@@ -67,13 +72,11 @@ const Footer = () => {
           </a>
         </div>
 
-        {versions && (versions.ui_version || etlLabel) && (
-          <div className="footer-section footer-versions">
-            {versions.ui_version && <span>UI {versions.ui_version}</span>}
-            {versions.ui_version && etlLabel && <span> · </span>}
-            {etlLabel && <span>{etlLabel}</span>}
-          </div>
-        )}
+        <div className="footer-section footer-versions">
+          <span>UI {uiVersion}</span>
+          {etlLabel && <span> · </span>}
+          {etlLabel && <span>{etlLabel}</span>}
+        </div>
 
         <div className="footer-section footer-copyright">
           <p>© {currentYear} National Library of Medicine (NLM).</p>

--- a/react/src/components/Footer/Footer.test.js
+++ b/react/src/components/Footer/Footer.test.js
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { fetchVersionInfo } from "services";
 import Footer from "./Footer";
 
+process.env.REACT_APP_VERSION = "test-bundle-version";
+
 jest.mock("services", () => ({
   fetchVersionInfo: jest.fn(),
 }));
@@ -18,20 +20,18 @@ describe("Footer Component", () => {
 
   test("displays the UI and ETL versions when the fetch succeeds", async () => {
     fetchVersionInfo.mockResolvedValue({
-      ui_version: "v1.0.0",
       etl_version: "v1.4.6-alpha.28",
       pinned_etl_version: "v1.4.6-alpha.28",
     });
 
     render(<Footer />);
 
-    expect(await screen.findByText(/v1\.0\.0/)).toBeInTheDocument();
+    expect(await screen.findByText(/UI test-bundle-version/)).toBeInTheDocument();
     expect(await screen.findByText(/v1\.4\.6-alpha\.28/)).toBeInTheDocument();
   });
 
   test("does not mention the pin when the loaded version matches it", async () => {
     fetchVersionInfo.mockResolvedValue({
-      ui_version: "v1.0.0",
       etl_version: "v1.5.0-rc.1",
       pinned_etl_version: "v1.5.0-rc.1",
     });
@@ -44,7 +44,6 @@ describe("Footer Component", () => {
 
   test("flags the pinned version when the loaded dataset differs", async () => {
     fetchVersionInfo.mockResolvedValue({
-      ui_version: "v1.0.0",
       etl_version: "v1.4.6-rc.6",
       pinned_etl_version: "v1.5.0-rc.1",
     });
@@ -58,7 +57,6 @@ describe("Footer Component", () => {
 
   test("flags the pinned version when the loaded dataset is unknown", async () => {
     fetchVersionInfo.mockResolvedValue({
-      ui_version: "v1.0.0",
       etl_version: "unknown",
       pinned_etl_version: "v1.5.0-rc.1",
     });
@@ -70,15 +68,33 @@ describe("Footer Component", () => {
 
   test("does not render an ETL label when pinned_etl_version is absent (old backend)", async () => {
     fetchVersionInfo.mockResolvedValue({
-      ui_version: "v1.0.0",
       etl_version: "v1.5.0-rc.1",
     });
 
     render(<Footer />);
 
-    expect(await screen.findByText(/v1\.0\.0/)).toBeInTheDocument();
+    expect(await screen.findByText(/UI test-bundle-version/)).toBeInTheDocument();
     expect(screen.queryByText(/ETL/)).not.toBeInTheDocument();
     expect(screen.queryByText(/pinned/)).not.toBeInTheDocument();
+  });
+
+  test("displays the UI version baked into the bundle", async () => {
+    fetchVersionInfo.mockResolvedValue({
+      etl_version: "v1.5.0-rc.1",
+      pinned_etl_version: "v1.5.0-rc.1",
+    });
+
+    render(<Footer />);
+
+    expect(await screen.findByText(/UI test-bundle-version/)).toBeInTheDocument();
+  });
+
+  test("shows the UI version even when the version fetch fails", async () => {
+    fetchVersionInfo.mockResolvedValue(null);
+
+    render(<Footer />);
+
+    expect(await screen.findByText(/UI test-bundle-version/)).toBeInTheDocument();
   });
 
   test("still renders the footer when the version fetch fails", async () => {

--- a/react/src/services/api/versions.js
+++ b/react/src/services/api/versions.js
@@ -2,10 +2,14 @@ import { VERSION_ENDPOINT } from "constants/index";
 import { getJson } from "./fetchWrapper";
 
 /**
- * Fetch the UI version, the ETL version of the loaded dataset, and the pinned
- * ETL version, for display in the footer.
- * Non-critical: returns null on any failure instead of throwing.
- * @returns {Promise<{ui_version: string, etl_version: string, pinned_etl_version: string} | null>}
+ * Fetch the ETL version of the loaded dataset and the pinned ETL version, for
+ * display in the footer. The UI version is baked into the bundle, not fetched.
+ * `backend_version` is returned for diagnosis but is not displayed.
+ *
+ * All fields are optional: a backend predating this feature omits
+ * `pinned_etl_version`, which the footer treats as "cannot substantiate a
+ * loaded version" and renders no ETL label at all.
+ * @returns {Promise<{backend_version?: string, etl_version?: string, pinned_etl_version?: string} | null>}
  */
 export const fetchVersionInfo = async () => {
   return getJson(VERSION_ENDPOINT, { fallback: null, silent: true });

--- a/scripts/app/deploy-frontend.sh
+++ b/scripts/app/deploy-frontend.sh
@@ -139,7 +139,23 @@ echo -e "${YELLOW}Running npm install (if needed)...${NC}"
 npm ci --prefer-offline --no-audit
 
 echo -e "${YELLOW}Building React application...${NC}"
-npm run build-react
+# Bake the version into the bundle so the string ships inside the artifact it
+# names. The backend image tag cannot serve this: frontend and backend deploy
+# independently and conditionally (ci.yml), so a frontend-only change would
+# leave the backend — and any version it reported — untouched.
+#
+# Same resolution rule as deploy-backend.sh's IMAGE_TAG, so both halves report
+# the same shape of version in a given environment: an explicit override if
+# set, otherwise the short git SHA.
+if [ -z "${VERSION:-}" ]; then
+  VERSION=$(git rev-parse --short HEAD 2>/dev/null) || {
+    echo -e "${RED}Error: could not determine a version (not a git checkout?)${NC}"
+    echo "Set the VERSION environment variable to override."
+    exit 1
+  }
+fi
+echo -e "${YELLOW}Building with REACT_APP_VERSION=$VERSION${NC}"
+REACT_APP_VERSION="$VERSION" npm run build-react
 
 if [ ! -d "build" ]; then
     echo -e "${RED}Error: Build directory not found!${NC}"


### PR DESCRIPTION
Automated promotion from Springbok-LLC fork. Merged with admin bypass — Springbok-LLC's CI gates the commits before they land here.